### PR TITLE
Add initial Jekyll site structure with example guideline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# MyPhysioMaster2.0
+MyPhysioMaster — Hub de Guidelines (GitHub Pages + Jekyll)
+Como usar:
+- Suba estes arquivos no repositório público.
+- Em Settings → Pages, selecione Branch = main / root.
+- Acesse: https://SEU-USUARIO.github.io/NOME-DO-REPO/
+Criar nova guideline:
+- Duplique _guidelines/_TEMPLATE.md, preencha e faça commit.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,16 @@
+title: MyPhysioMaster
+description: Resumos práticos de guidelines para fisioterapeutas
+theme: minima
+permalink: pretty
+collections:
+  guidelines:
+    output: true
+    permalink: /guidelines/:name/
+defaults:
+  - scope: { path: "", type: "guidelines" }
+    values: { layout: guideline, toc: true }
+markdown: kramdown
+kramdown: { input: GFM }
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap

--- a/_guidelines/_TEMPLATE.md
+++ b/_guidelines/_TEMPLATE.md
@@ -1,0 +1,23 @@
+---
+title: <TÍTULO> — <ORG> <ANO>
+organization: <ORG>
+year: <ANO>
+date: 2025-01-01
+tags: [<tags>]
+pico: |
+  <Pergunta clínica em 1–3 linhas>
+recommendations:
+  - {text: "<Recomendação 1>", strength: "<Forte/Moderada/Fraca/Contra>"}
+  - {text: "<Recomendação 2>", strength: "<Forte/Moderada/Fraca/Contra>"}
+care_pathway: |
+  <Passos principais>
+outcomes: |
+  <Desfechos/MCIDs>
+br_context: |
+  <Adaptação Brasil>
+pitfalls: |
+  <Armadilhas>
+references:
+  - {title: "<Referência principal>", url: "https://..."}
+---
+<Resumo introdutório opcional>

--- a/_guidelines/pfp.md
+++ b/_guidelines/pfp.md
@@ -1,0 +1,29 @@
+---
+title: Dor Patelofemoral — CPG JOSPT 2019
+organization: JOSPT
+year: 2019
+date: 2019-06-01
+tags: [joelho, patelofemoral]
+pico: |
+  Em adultos com dor patelofemoral, quais intervenções melhoram dor e função?
+recommendations:
+  - {text: "Exercícios de quadríceps e quadril", strength: "Forte"}
+  - {text: "Educação e modulação de carga", strength: "Moderada"}
+  - {text: "Taping patelar como adjuvante de curto prazo", strength: "Fraca"}
+  - {text: "Evitar eletroterapia isolada", strength: "Contra"}
+care_pathway: |
+  1. Triagem (bandeiras vermelhas/psicossociais)  
+  2. Avaliação de força/controle de quadril e joelho  
+  3. Exercícios progressivos (fortalecimento + funcionais)  
+  4. Educação sobre carga e retorno
+outcomes: |
+  - **AKPS** (MCID ~10)  
+  - **NPRS** (MCID ~1.5–2.0)
+br_context: |
+  Exercícios com elásticos e peso corporal; atenção à progressão de volume; taping com fita elástica comum.
+pitfalls: |
+  Focar só em VMO; ignorar controle de carga.
+references:
+  - {title: "Willy RW et al. JOSPT Clinical Practice Guideline, 2019", url: "https://www.jospt.org/doi/10.2519/jospt.2019.0302"}
+---
+Conteúdo introdutório. Preencha as seções acima com o resumo.

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,0 +1,5 @@
+<nav>
+  <a href="{{ '/' | relative_url }}">Início</a> ·
+  <a href="{{ '/sobre/' | relative_url }}">Sobre</a> ·
+  <a href="{{ '/guidelines/' | relative_url }}">Todas as guidelines</a>
+</nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html><html lang="pt-BR"><head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{ page.title }} | {{ site.title }}</title>
+{%- seo -%}
+<link rel="stylesheet" href="{{ '/assets/style.css' | relative_url }}">
+</head><body class="container">
+<header>
+  <h1><a href="{{ '/' | relative_url }}">{{ site.title }}</a></h1>
+  <p>{{ site.description }}</p>
+  {% include nav.html %}<hr>
+</header>
+<main>{{ content }}</main>
+<footer><hr>
+  <small>📌 Conteúdo educativo. Não substitui avaliação clínica individual. — Build: {{ site.time | date: "%Y-%m-%d" }}</small>
+</footer>
+</body></html>

--- a/_layouts/guideline.html
+++ b/_layouts/guideline.html
@@ -1,0 +1,18 @@
+---
+layout: default
+---
+<article class="guideline">
+  <h1>{{ page.title }}</h1>
+  <p><strong>Órgão:</strong> {{ page.organization }} · <strong>Ano:</strong> {{ page.year }} · <strong>Atualizado:</strong> {{ page.updated | default: page.date | date: "%Y-%m-%d" }}</p>
+  {% if page.tags %}<p><strong>Tags:</strong> {{ page.tags | join: ', ' }}</p>{% endif %}
+  <h2>🔎 PICO</h2>{{ page.pico | markdownify }}
+  <h2>📌 Recomendações</h2>
+  <ul>{% for rec in page.recommendations %}<li>{{ rec.text }} — <em>{{ rec.strength }}</em></li>{% endfor %}</ul>
+  {% if page.care_pathway %}<h2>🧭 Linha de cuidado</h2>{{ page.care_pathway | markdownify }}{% endif %}
+  {% if page.outcomes %}<h2>🎯 Desfechos/MCID</h2>{{ page.outcomes | markdownify }}{% endif %}
+  <h2>🇧🇷 Aplicação no Brasil</h2>{{ page.br_context | markdownify }}
+  {% if page.pitfalls %}<h2>⚠️ Armadilhas</h2>{{ page.pitfalls | markdownify }}{% endif %}
+  <h2>📖 Referências</h2>
+  <ul>{% for ref in page.references %}<li><a href="{{ ref.url }}">{{ ref.title }}</a></li>{% endfor %}</ul>
+  <p><a href="{{ '/' | relative_url }}">⬅ Voltar</a></p>
+</article>

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,3 @@
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;max-width:900px;margin:auto;padding:1rem;line-height:1.6}
+h1,h2{line-height:1.25} nav a{margin-right:.75rem} ul{padding-left:1.25rem}
+.guideline li{margin-bottom:.35rem} code,pre{background:#f6f8fa;padding:.15rem .3rem;border-radius:4px}

--- a/guidelines.md
+++ b/guidelines.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Todas as guidelines
+permalink: /guidelines/
+---
+## Todas as guidelines
+<ul>
+{% assign sorted = site.guidelines | sort: 'title' %}
+{% for g in sorted %}
+  <li><a href="{{ g.url | relative_url }}">{{ g.title }}</a> — {{ g.year }} ({{ g.organization }})</li>
+{% endfor %}
+</ul>

--- a/index.md
+++ b/index.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Início
+---
+## Resumos de Guidelines em Fisioterapia
+Bem-vindo ao **MyPhysioMaster**. Aqui você encontra resumos práticos baseados em diretrizes.
+
+### Últimos conteúdos
+<ul>
+{% assign posts = site.guidelines | sort: 'date' | reverse %}
+{% for g in posts limit:10 %}
+  <li><a href="{{ g.url | relative_url }}">{{ g.title }}</a> — {{ g.year }} ({{ g.organization }})</li>
+{% endfor %}
+</ul>
+
+[Ver todas as guidelines](/guidelines/)

--- a/sobre.md
+++ b/sobre.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Sobre
+permalink: /sobre/
+---
+## Sobre o projeto
+- Conteúdo educativo baseado em diretrizes (citadas e linkadas).
+- Resumos próprios com adaptação ao contexto do Brasil quando pertinente.
+- Registro de data de revisão em cada página.
+
+### Contato
+- E-mail: contato@exemplo.com


### PR DESCRIPTION
## Summary
- Configure Jekyll site with collections for guidelines and basic theme
- Add default and guideline layouts with navigation and simple styling
- Include example patellofemoral pain guideline and template for new entries

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5131f72e4832eaac2d79d680d4e1b